### PR TITLE
feat: add TLS support and improve OIDC claim parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,10 @@ The heavy lifting (GraphQL schema generation, query execution, data source manag
 3. **Cluster Worker** — `CLUSTER_ENABLED=true CLUSTER_ROLE=worker`. CoreDB must be PostgreSQL (same as management). Reads compiled schema, syncs secrets, serves queries.
 
 Cluster mode always requires PostgreSQL as CoreDB. The server validates this at startup.
+
+## Active Technologies
+- Go 1.26+ + stdlib `net/http`, `crypto/tls` (no new external deps) (002-tls-support)
+- N/A (reads certificate files from filesystem) (002-tls-support)
+
+## Recent Changes
+- 002-tls-support: Added Go 1.26+ + stdlib `net/http`, `crypto/tls` (no new external deps)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 LDFLAGS := "-X 'main.Version=$(GIT_VERSION)' -X 'main.BuildDate=$(BUILD_DATE)'"
 
 # Targets
-.PHONY: all server migrate clean test e2e
+.PHONY: all server migrate clean test e2e certs
 
 all: server migrate
 
@@ -19,6 +19,13 @@ test:
 
 e2e:
 	bash integration-test/e2e/run.sh
+
+certs:
+	mkdir -p .local/certs
+	openssl req -x509 -newkey rsa:2048 -keyout .local/certs/server.key \
+		-out .local/certs/server.crt -days 365 -nodes \
+		-subj "/CN=localhost" \
+		-addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
 
 clean:
 	rm -f server migrate

--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ CORE_DB_PATH="postgres://user:pass@db:5432/hugr" \
 - MAX_PARALLEL_QUERIES - limit to numbers of parallels queries executed, default: 0 (unlimited)
 - MAX_DEPTH - maximal depth of GraphQL types hierarchy, default: 7
 
+### TLS
+
+- TLS_CERT_FILE - path to PEM-encoded TLS certificate file, default: "" (disabled). When set together with TLS_KEY_FILE, the server serves HTTPS instead of HTTP.
+- TLS_KEY_FILE - path to PEM-encoded TLS private key file, default: "" (disabled). Both TLS_CERT_FILE and TLS_KEY_FILE must be set together.
+
+Example:
+```bash
+TLS_CERT_FILE=/etc/ssl/certs/hugr.crt \
+TLS_KEY_FILE=/etc/ssl/private/hugr.key \
+BIND=:443 \
+./server
+```
+
+For local development, generate self-signed certificates with `make certs` and use the TLS-enabled `.env` files in `.local/`.
+
+**Note**: The sidecar service endpoint (health/metrics on `SERVICE_BIND`) always uses plain HTTP regardless of TLS configuration.
+
 ### DuckDB engine settings
 
 - DB_HOME_DIRECTORY - path to the DuckDB home directory, default: "", example: "/data/.hugr". This very important to make persistence secrets (like S3 credentials) in container environments.

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -42,6 +42,9 @@ type Config struct {
 
 	Cache    cache.Config
 	Embedder hugr.EmbedderConfig
+
+	TLSCertFile string
+	TLSKeyFile  string
 }
 
 func init() {
@@ -70,6 +73,8 @@ func initEnvs() {
 	viper.SetDefault("CLUSTER_HEARTBEAT", 30*time.Second)
 	viper.SetDefault("CLUSTER_GHOST_TTL", 2*time.Minute)
 	viper.SetDefault("CLUSTER_POLL_INTERVAL", 30*time.Second)
+	viper.SetDefault("TLS_CERT_FILE", "")
+	viper.SetDefault("TLS_KEY_FILE", "")
 	viper.AutomaticEnv()
 }
 
@@ -152,6 +157,8 @@ func loadConfig() Config {
 			URL:        viper.GetString("EMBEDDER_URL"),
 			VectorSize: viper.GetInt("EMBEDDER_VECTOR_SIZE"),
 		},
+		TLSCertFile: viper.GetString("TLS_CERT_FILE"),
+		TLSKeyFile:  viper.GetString("TLS_KEY_FILE"),
 		Cache: cache.Config{
 			TTL: types.Interval(viper.GetDuration("CACHE_TTL")),
 			L1: cache.L1Config{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"errors"
 	"flag"
@@ -35,6 +36,20 @@ func main() {
 		return
 	}
 	config := loadConfig()
+
+	// Validate TLS configuration
+	tlsEnabled := config.TLSCertFile != "" || config.TLSKeyFile != ""
+	if tlsEnabled {
+		if config.TLSCertFile == "" || config.TLSKeyFile == "" {
+			log.Println("Both TLS_CERT_FILE and TLS_KEY_FILE must be set when enabling TLS")
+			os.Exit(1)
+		}
+		_, err := tls.LoadX509KeyPair(config.TLSCertFile, config.TLSKeyFile)
+		if err != nil {
+			log.Printf("TLS configuration error: %v\n", err)
+			os.Exit(1)
+		}
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 	defer stop()
@@ -141,11 +156,20 @@ func main() {
 	}
 
 	go func() {
-		log.Println("Starting server on ", config.Bind)
+		if tlsEnabled {
+			log.Printf("Starting server on %s (HTTPS)\n", config.Bind)
+		} else {
+			log.Printf("Starting server on %s (HTTP)\n", config.Bind)
+		}
 		if config.DebugMode {
 			log.Println("Debug mode on")
 		}
-		err := srv.ListenAndServe()
+		var err error
+		if tlsEnabled {
+			err = srv.ListenAndServeTLS(config.TLSCertFile, config.TLSKeyFile)
+		} else {
+			err = srv.ListenAndServe()
+		}
 		if errors.Is(err, http.ErrServerClosed) {
 			log.Println("Server stopped")
 			return

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/duckdb/duckdb-go/v2"
@@ -38,20 +39,24 @@ func main() {
 	config := loadConfig()
 
 	// Validate TLS configuration
+	var tlsCfg *tls.Config
 	tlsEnabled := config.TLSCertFile != "" || config.TLSKeyFile != ""
 	if tlsEnabled {
 		if config.TLSCertFile == "" || config.TLSKeyFile == "" {
 			log.Println("Both TLS_CERT_FILE and TLS_KEY_FILE must be set when enabling TLS")
 			os.Exit(1)
 		}
-		_, err := tls.LoadX509KeyPair(config.TLSCertFile, config.TLSKeyFile)
+		cert, err := tls.LoadX509KeyPair(config.TLSCertFile, config.TLSKeyFile)
 		if err != nil {
 			log.Printf("TLS configuration error: %v\n", err)
 			os.Exit(1)
 		}
+		tlsCfg = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+		}
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	// Validate cluster configuration
@@ -151,8 +156,9 @@ func main() {
 	}
 
 	srv := &http.Server{
-		Addr:    config.Bind,
-		Handler: cors.Middleware(config.Cors)(handler),
+		Addr:      config.Bind,
+		Handler:   cors.Middleware(config.Cors)(handler),
+		TLSConfig: tlsCfg,
 	}
 
 	go func() {
@@ -166,7 +172,7 @@ func main() {
 		}
 		var err error
 		if tlsEnabled {
-			err = srv.ListenAndServeTLS(config.TLSCertFile, config.TLSKeyFile)
+			err = srv.ListenAndServeTLS("", "")
 		} else {
 			err = srv.ListenAndServe()
 		}

--- a/pkg/auth/oidc_provider.go
+++ b/pkg/auth/oidc_provider.go
@@ -77,7 +77,7 @@ func NewOIDCProvider(ctx context.Context, c OIDCConfig) (*OIDCProvider, error) {
 		c.Claims.UserName = "name"
 	}
 	if c.ScopeRolePrefix == "" {
-		c.ScopeRolePrefix = "hugr:"
+		c.ScopeRolePrefix = ""
 	}
 
 	return &OIDCProvider{
@@ -108,8 +108,7 @@ func (p *OIDCProvider) Authenticate(r *http.Request) (*auth.AuthInfo, error) {
 	}
 
 	idToken, err := p.verifier.Verify(r.Context(), token)
-	var oidcErr *oidc.TokenExpiredError
-	if errors.As(err, &oidcErr) {
+	if _, ok := errors.AsType[*oidc.TokenExpiredError](err); ok {
 		return nil, auth.ErrTokenExpired
 	}
 	if err != nil {
@@ -121,25 +120,17 @@ func (p *OIDCProvider) Authenticate(r *http.Request) (*auth.AuthInfo, error) {
 		return nil, auth.ErrForbidden
 	}
 
-	role, _ := claims[p.c.Claims.Role].(string)
-	userId, _ := claims[p.c.Claims.UserId].(string)
-	userName, _ := claims[p.c.Claims.UserName].(string)
+	role := claimString(claims, p.c.Claims.Role, p.c.ScopeRolePrefix)
+	userId := claimString(claims, p.c.Claims.UserId, "")
+	userName := claimString(claims, p.c.Claims.UserName, "")
 
 	// check scopes if role is empty
 	if role == "" {
-		scopes, ok := claims["scopes"].([]any)
-		if ok {
-			for _, scope := range scopes {
-				if s, ok := scope.(string); ok {
-					if strings.HasPrefix(s, p.c.ScopeRolePrefix) {
-						if role == "" || strings.HasSuffix(s, role) {
-							role = strings.TrimPrefix(s, p.c.ScopeRolePrefix)
-							break
-						}
-					}
-				}
-			}
-		}
+		role = claimString(claims, "scopes", p.c.ScopeRolePrefix)
+	}
+
+	if role == "" {
+		return nil, auth.ErrForbidden
 	}
 
 	return &auth.AuthInfo{
@@ -150,4 +141,45 @@ func (p *OIDCProvider) Authenticate(r *http.Request) (*auth.AuthInfo, error) {
 		AuthProvider: p.Name(),
 		Token:        token,
 	}, nil
+}
+
+// claimString extracts a string value from a claim, if prefix is provided, it return only unprefixed value with it.
+// claims can be in different formats, for example:
+// "scopes": ["hugr:admin", "app:user"] -> for prefix "hugr:" it will return "admin", for prefix "app:" it will return "user", for prefix "" it will return "hugr:admin" (first match)
+// "roles": "hugr:user" -> for prefix "hugr:" it will return "user", for prefix "" it will return "hugr:user", for prefix "app:" it will return "" (no match)
+// "x-hugr-role": "admin"
+func claimString(claims jwt.MapClaims, key, prefix string) string {
+	if len(claims) == 0 {
+		return ""
+	}
+	v, ok := claims[key]
+	if !ok {
+		return ""
+	}
+	var s string
+	switch val := v.(type) {
+	case string:
+		if after, ok := strings.CutPrefix(val, prefix); ok {
+			s = after
+		}
+	case []any:
+		for _, item := range val {
+			str, ok := item.(string)
+			if !ok {
+				continue
+			}
+			if after, ok := strings.CutPrefix(str, prefix); ok {
+				s = after
+				break
+			}
+		}
+	case []string:
+		for _, str := range val {
+			if after, ok := strings.CutPrefix(str, prefix); ok {
+				s = after
+				break
+			}
+		}
+	}
+	return s
 }

--- a/pkg/auth/oidc_provider.go
+++ b/pkg/auth/oidc_provider.go
@@ -76,10 +76,6 @@ func NewOIDCProvider(ctx context.Context, c OIDCConfig) (*OIDCProvider, error) {
 	if c.Claims.UserName == "" {
 		c.Claims.UserName = "name"
 	}
-	if c.ScopeRolePrefix == "" {
-		c.ScopeRolePrefix = ""
-	}
-
 	return &OIDCProvider{
 		c:         c,
 		verifier:  verifier,


### PR DESCRIPTION
## Summary
- Add optional TLS termination via `TLS_CERT_FILE` / `TLS_KEY_FILE` env vars with early certificate validation at startup
- Add `make certs` target for generating self-signed dev certificates
- Refactor OIDC provider: generic `claimString` helper for string/array claim formats, remove default scope role prefix, require role presence
- Sidecar (health/metrics) always serves plain HTTP regardless of TLS config

## Test plan
- [ ] Start server with `TLS_CERT_FILE` and `TLS_KEY_FILE` set — verify HTTPS
- [ ] Start server without TLS vars — verify plain HTTP still works
- [ ] Set only one of the two TLS vars — verify startup error
- [ ] Point to invalid cert/key files — verify startup error
- [ ] Verify OIDC authentication with string and array claim formats
- [ ] Verify role is required (empty role returns 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)