### PR TITLE
feat: stateless OAuth 2.1 proxy for MCP OIDC authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,10 @@ Cluster mode always requires PostgreSQL as CoreDB. The server validates this at 
 ## Active Technologies
 - Go 1.26+ + stdlib `net/http`, `crypto/tls` (no new external deps) (002-tls-support)
 - N/A (reads certificate files from filesystem) (002-tls-support)
+- Go 1.26+ + `golang-jwt/jwt/v5` (direct), `coreos/go-oidc/v3` (direct), `golang.org/x/oauth2` (indirect→direct), `go-jose/go-jose/v4` (indirect) (003-mcp-oidc-auth)
+- In-memory (sync.Map with TTL) for auth codes, client registrations, refresh tokens. No DB changes. (003-mcp-oidc-auth)
+- Go 1.26+ + `coreos/go-oidc/v3` (direct), `golang.org/x/oauth2` (indirect→direct) (003-mcp-oidc-auth)
+- None. Fully stateless — transient data encrypted into request/response parameters with `SECRET_KEY`. (003-mcp-oidc-auth)
 
 ## Recent Changes
 - 002-tls-support: Added Go 1.26+ + stdlib `net/http`, `crypto/tls` (no new external deps)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 LDFLAGS := "-X 'main.Version=$(GIT_VERSION)' -X 'main.BuildDate=$(BUILD_DATE)'"
 
 # Targets
-.PHONY: all server migrate clean test e2e certs
+.PHONY: all server migrate clean test e2e certs tunnel
 
 all: server migrate
 
@@ -26,6 +26,9 @@ certs:
 		-out .local/certs/server.crt -days 365 -nodes \
 		-subj "/CN=localhost" \
 		-addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+tunnel:
+	cloudflared tunnel run --url http://localhost:15000 hugr-dev
 
 clean:
 	rm -f server migrate

--- a/README.md
+++ b/README.md
@@ -107,6 +107,50 @@ For local development, generate self-signed certificates with `make certs` and u
 
 **Note**: The sidecar service endpoint (health/metrics on `SERVICE_BIND`) always uses plain HTTP regardless of TLS configuration.
 
+### MCP OAuth (OIDC Authentication for MCP Clients)
+
+When MCP is enabled (`MCP_ENABLED=true`) and OIDC is configured, Hugr can act as a stateless OAuth 2.1 proxy so that MCP clients (Claude Desktop, Cursor, etc.) can authenticate via your OIDC provider.
+
+**Required environment variables** (in addition to existing OIDC config):
+
+- OIDC_CLIENT_SECRET - client secret for the OIDC authorization code exchange, default: "" (OAuth proxy disabled)
+- OIDC_SCOPES - space-separated scopes to request from the OIDC provider, default: "openid profile email"
+- OIDC_REDIRECT_URL - optional override for Hugr's OAuth callback URL (auto-derived from Host header if not set)
+- SECRET_KEY - required for encrypting OAuth state (must be set when using MCP OAuth)
+
+**How it works**: Hugr exposes `/.well-known/oauth-authorization-server` metadata pointing to its own `/oauth/authorize`, `/oauth/token`, and `/oauth/register` endpoints. MCP clients discover these endpoints, register dynamically, and complete an Authorization Code + PKCE flow. Hugr proxies the authentication to the external OIDC provider and passes the OIDC tokens back to the client. The existing auth middleware validates the tokens on subsequent MCP requests.
+
+**Setup with Cloudflare Tunnel** (for local development):
+```bash
+# Create a named tunnel (one-time)
+cloudflared tunnel create hugr-dev
+cloudflared tunnel route dns hugr-dev hugr-dev.yourdomain.com
+
+# Configure OIDC provider with redirect URI: https://hugr-dev.yourdomain.com/oauth/callback
+
+# Run Hugr + tunnel
+MCP_ENABLED=true \
+OIDC_ISSUER=https://your-provider.com/realms/your-realm \
+OIDC_CLIENT_ID=hugr-server \
+OIDC_CLIENT_SECRET=your-secret \
+SECRET_KEY=your-secret-key \
+ALLOWED_ANONYMOUS=false \
+./server &
+
+cloudflared tunnel run --url http://localhost:15000 hugr-dev
+```
+
+Then in Claude Desktop settings:
+```json
+{
+  "mcpServers": {
+    "hugr": {
+      "url": "https://hugr-dev.yourdomain.com/mcp"
+    }
+  }
+}
+```
+
 ### DuckDB engine settings
 
 - DB_HOME_DIRECTORY - path to the DuckDB home directory, default: "", example: "/data/.hugr". This very important to make persistence secrets (like S3 credentials) in container environments.

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -76,6 +76,8 @@ func initEnvs() {
 	viper.SetDefault("OIDC_CLIENT_SECRET", "")
 	viper.SetDefault("OIDC_SCOPES", "openid profile email")
 	viper.SetDefault("OIDC_REDIRECT_URL", "")
+	viper.SetDefault("MCP_OAUTH_CLIENT_ID", "")
+	viper.SetDefault("MCP_OAUTH_CLIENT_SECRET", "")
 	viper.SetDefault("TLS_CERT_FILE", "")
 	viper.SetDefault("TLS_KEY_FILE", "")
 	viper.AutomaticEnv()

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -73,6 +73,9 @@ func initEnvs() {
 	viper.SetDefault("CLUSTER_HEARTBEAT", 30*time.Second)
 	viper.SetDefault("CLUSTER_GHOST_TTL", 2*time.Minute)
 	viper.SetDefault("CLUSTER_POLL_INTERVAL", 30*time.Second)
+	viper.SetDefault("OIDC_CLIENT_SECRET", "")
+	viper.SetDefault("OIDC_SCOPES", "openid profile email")
+	viper.SetDefault("OIDC_REDIRECT_URL", "")
 	viper.SetDefault("TLS_CERT_FILE", "")
 	viper.SetDefault("TLS_KEY_FILE", "")
 	viper.AutomaticEnv()
@@ -145,7 +148,10 @@ func loadConfig() Config {
 				Timeout:         viper.GetDuration("OIDC_TIMEOUT"),
 				TLSInsecure:     viper.GetBool("OIDC_TLS_INSECURE"),
 				CookieName:      viper.GetString("OIDC_COOKIE_NAME"),
-				ScopeRolePrefix: viper.GetString("OIDC_SCOPE_ROLE_PREFIX"),
+				ClientSecret:    viper.GetString("OIDC_CLIENT_SECRET"),
+			Scopes:          viper.GetString("OIDC_SCOPES"),
+			RedirectURL:     viper.GetString("OIDC_REDIRECT_URL"),
+			ScopeRolePrefix: viper.GetString("OIDC_SCOPE_ROLE_PREFIX"),
 				Claims: auth.OIDCClaims{
 					UserName: viper.GetString("OIDC_USERNAME_CLAIM"),
 					UserId:   viper.GetString("OIDC_USERID_CLAIM"),

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -45,6 +45,9 @@ type Config struct {
 
 	TLSCertFile string
 	TLSKeyFile  string
+
+	MCPOAuthClientID     string
+	MCPOAuthClientSecret string
 }
 
 func init() {
@@ -165,8 +168,10 @@ func loadConfig() Config {
 			URL:        viper.GetString("EMBEDDER_URL"),
 			VectorSize: viper.GetInt("EMBEDDER_VECTOR_SIZE"),
 		},
-		TLSCertFile: viper.GetString("TLS_CERT_FILE"),
-		TLSKeyFile:  viper.GetString("TLS_KEY_FILE"),
+		TLSCertFile:          viper.GetString("TLS_CERT_FILE"),
+		TLSKeyFile:           viper.GetString("TLS_KEY_FILE"),
+		MCPOAuthClientID:     viper.GetString("MCP_OAUTH_CLIENT_ID"),
+		MCPOAuthClientSecret: viper.GetString("MCP_OAUTH_CLIENT_SECRET"),
 		Cache: cache.Config{
 			TTL: types.Interval(viper.GetDuration("CACHE_TTL")),
 			L1: cache.L1Config{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/duckdb/duckdb-go/v2"
 	"github.com/hugr-lab/hugr/pkg/auth"
+	"github.com/hugr-lab/hugr/pkg/auth/oauth"
 	"github.com/hugr-lab/hugr/pkg/cors"
 	"github.com/hugr-lab/hugr/pkg/info"
 	"github.com/hugr-lab/hugr/pkg/service"
@@ -147,10 +148,29 @@ func main() {
 
 	var handler http.Handler = engine
 
-	// Add /auth/config endpoint if OIDC is configured
+	// Add /auth/config and OAuth proxy endpoints if OIDC is configured
 	if config.Auth.OIDCEnabled() {
 		mux := http.NewServeMux()
 		mux.HandleFunc("GET /auth/config", config.Auth.AuthConfigHandler())
+
+		// Mount OAuth proxy for MCP clients when MCP is enabled
+		if config.MCPEnabled && config.Auth.OIDC.ClientSecret != "" {
+			oauthProxy, err := oauth.NewProxy(ctx, oauth.Config{
+				Issuer:       config.Auth.OIDC.Issuer,
+				ClientID:     config.Auth.OIDC.ClientID,
+				ClientSecret: config.Auth.OIDC.ClientSecret,
+				Scopes:       config.Auth.OIDC.Scopes,
+				RedirectURL:  config.Auth.OIDC.RedirectURL,
+				SecretKey:    config.Auth.SecretKey,
+			})
+			if err != nil {
+				log.Println("OAuth proxy initialization error:", err)
+				os.Exit(1)
+			}
+			oauthProxy.RegisterHandlers(mux)
+			log.Println("MCP OAuth proxy enabled")
+		}
+
 		mux.Handle("/", engine)
 		handler = mux
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hugr-lab/hugr/pkg/auth"
 	"github.com/hugr-lab/hugr/pkg/auth/oauth"
 	"github.com/hugr-lab/hugr/pkg/cors"
-	"github.com/spf13/viper"
 	"github.com/hugr-lab/hugr/pkg/info"
 	"github.com/hugr-lab/hugr/pkg/service"
 	hugr "github.com/hugr-lab/query-engine"
@@ -155,8 +154,8 @@ func main() {
 		mux.HandleFunc("GET /auth/config", config.Auth.AuthConfigHandler())
 
 		// Mount OAuth proxy for MCP clients when MCP is enabled
-		mcpClientID := viper.GetString("MCP_OAUTH_CLIENT_ID")
-		mcpClientSecret := viper.GetString("MCP_OAUTH_CLIENT_SECRET")
+		mcpClientID := config.MCPOAuthClientID
+		mcpClientSecret := config.MCPOAuthClientSecret
 		// Fall back to OIDC client credentials if MCP-specific ones are not set
 		if mcpClientID == "" {
 			mcpClientID = config.Auth.OIDC.ClientID

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hugr-lab/hugr/pkg/auth"
 	"github.com/hugr-lab/hugr/pkg/auth/oauth"
 	"github.com/hugr-lab/hugr/pkg/cors"
+	"github.com/spf13/viper"
 	"github.com/hugr-lab/hugr/pkg/info"
 	"github.com/hugr-lab/hugr/pkg/service"
 	hugr "github.com/hugr-lab/query-engine"
@@ -154,13 +155,23 @@ func main() {
 		mux.HandleFunc("GET /auth/config", config.Auth.AuthConfigHandler())
 
 		// Mount OAuth proxy for MCP clients when MCP is enabled
-		if config.MCPEnabled && config.Auth.OIDC.ClientSecret != "" {
+		mcpClientID := viper.GetString("MCP_OAUTH_CLIENT_ID")
+		mcpClientSecret := viper.GetString("MCP_OAUTH_CLIENT_SECRET")
+		// Fall back to OIDC client credentials if MCP-specific ones are not set
+		if mcpClientID == "" {
+			mcpClientID = config.Auth.OIDC.ClientID
+		}
+		if mcpClientSecret == "" {
+			mcpClientSecret = config.Auth.OIDC.ClientSecret
+		}
+		if config.MCPEnabled && mcpClientSecret != "" {
 			oauthProxy, err := oauth.NewProxy(ctx, oauth.Config{
 				Issuer:       config.Auth.OIDC.Issuer,
-				ClientID:     config.Auth.OIDC.ClientID,
-				ClientSecret: config.Auth.OIDC.ClientSecret,
+				ClientID:     mcpClientID,
+				ClientSecret: mcpClientSecret,
 				Scopes:       config.Auth.OIDC.Scopes,
 				RedirectURL:  config.Auth.OIDC.RedirectURL,
+				TLSInsecure:  config.Auth.OIDC.TLSInsecure,
 				SecretKey:    config.Auth.SecretKey,
 			})
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/viper v1.21.0
 	go.yaml.in/yaml/v3 v3.0.4
+	golang.org/x/oauth2 v0.36.0
 )
 
 require (
@@ -96,7 +97,6 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/pkg/auth/oauth/crypto.go
+++ b/pkg/auth/oauth/crypto.go
@@ -1,0 +1,135 @@
+package oauth
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// StatePayload is encrypted into the OAuth state parameter.
+// Carried from /oauth/authorize → OIDC provider → /oauth/callback.
+type StatePayload struct {
+	RedirectURI   string `json:"redirect_uri"`
+	CodeChallenge string `json:"code_challenge"`
+	ClientID      string `json:"client_id"`
+	ClientState   string `json:"client_state"`
+	Timestamp     int64  `json:"timestamp"`
+}
+
+// AuthCodePayload is encrypted into the authorization code.
+// Carried from /oauth/callback → MCP client → /oauth/token.
+type AuthCodePayload struct {
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in,omitempty"`
+	CodeChallenge string `json:"code_challenge"`
+	ClientID     string `json:"client_id"`
+	RedirectURI  string `json:"redirect_uri"`
+	Timestamp    int64  `json:"timestamp"`
+}
+
+// deriveKey derives a 32-byte AES-256 key from an arbitrary secret string.
+func deriveKey(secret string) []byte {
+	h := sha256.Sum256([]byte(secret))
+	return h[:]
+}
+
+// encrypt serializes v to JSON, encrypts with AES-256-GCM, and returns base64url.
+func encrypt(key []byte, v any) (string, error) {
+	plaintext, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("marshal: %w", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("new cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("new gcm: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("rand nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+	return base64.RawURLEncoding.EncodeToString(ciphertext), nil
+}
+
+// decrypt decodes base64url, decrypts AES-256-GCM, and unmarshals JSON into v.
+func decrypt(key []byte, encoded string, v any) error {
+	ciphertext, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("base64 decode: %w", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return fmt.Errorf("new cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("new gcm: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return fmt.Errorf("decrypt: %w", err)
+	}
+
+	return json.Unmarshal(plaintext, v)
+}
+
+// encryptState encrypts a StatePayload, setting the timestamp to now.
+func encryptState(key []byte, s *StatePayload) (string, error) {
+	s.Timestamp = time.Now().Unix()
+	return encrypt(key, s)
+}
+
+// decryptState decrypts and validates a StatePayload with TTL check.
+func decryptState(key []byte, encoded string, ttl time.Duration) (*StatePayload, error) {
+	var s StatePayload
+	if err := decrypt(key, encoded, &s); err != nil {
+		return nil, err
+	}
+	if time.Since(time.Unix(s.Timestamp, 0)) > ttl {
+		return nil, fmt.Errorf("state expired")
+	}
+	return &s, nil
+}
+
+// encryptAuthCode encrypts an AuthCodePayload, setting the timestamp to now.
+func encryptAuthCode(key []byte, a *AuthCodePayload) (string, error) {
+	a.Timestamp = time.Now().Unix()
+	return encrypt(key, a)
+}
+
+// decryptAuthCode decrypts and validates an AuthCodePayload with TTL check.
+func decryptAuthCode(key []byte, encoded string, ttl time.Duration) (*AuthCodePayload, error) {
+	var a AuthCodePayload
+	if err := decrypt(key, encoded, &a); err != nil {
+		return nil, err
+	}
+	if time.Since(time.Unix(a.Timestamp, 0)) > ttl {
+		return nil, fmt.Errorf("authorization code expired")
+	}
+	return &a, nil
+}

--- a/pkg/auth/oauth/crypto.go
+++ b/pkg/auth/oauth/crypto.go
@@ -99,7 +99,7 @@ func decrypt(key []byte, encoded string, v any) error {
 }
 
 // encryptState encrypts a StatePayload, setting the timestamp to now.
-func encryptState(key []byte, s *StatePayload) (string, error) {
+func encryptState(key []byte, s StatePayload) (string, error) {
 	s.Timestamp = time.Now().Unix()
 	return encrypt(key, s)
 }
@@ -117,7 +117,7 @@ func decryptState(key []byte, encoded string, ttl time.Duration) (*StatePayload,
 }
 
 // encryptAuthCode encrypts an AuthCodePayload, setting the timestamp to now.
-func encryptAuthCode(key []byte, a *AuthCodePayload) (string, error) {
+func encryptAuthCode(key []byte, a AuthCodePayload) (string, error) {
 	a.Timestamp = time.Now().Unix()
 	return encrypt(key, a)
 }

--- a/pkg/auth/oauth/crypto_test.go
+++ b/pkg/auth/oauth/crypto_test.go
@@ -1,0 +1,129 @@
+package oauth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	key := deriveKey("test-secret-key-for-testing")
+
+	original := map[string]string{"hello": "world", "foo": "bar"}
+	encoded, err := encrypt(key, original)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	var decoded map[string]string
+	if err := decrypt(key, encoded, &decoded); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	if decoded["hello"] != "world" || decoded["foo"] != "bar" {
+		t.Fatalf("unexpected decoded value: %v", decoded)
+	}
+}
+
+func TestDecryptTamperedData(t *testing.T) {
+	key := deriveKey("test-secret")
+
+	encoded, err := encrypt(key, map[string]string{"a": "b"})
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// Tamper with the ciphertext
+	tampered := []byte(encoded)
+	if len(tampered) > 5 {
+		tampered[5] ^= 0xff
+	}
+
+	var decoded map[string]string
+	if err := decrypt(key, string(tampered), &decoded); err == nil {
+		t.Fatal("expected error for tampered data, got nil")
+	}
+}
+
+func TestDecryptWrongKey(t *testing.T) {
+	key1 := deriveKey("key-one")
+	key2 := deriveKey("key-two")
+
+	encoded, err := encrypt(key1, "secret data")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	var decoded string
+	if err := decrypt(key2, encoded, &decoded); err == nil {
+		t.Fatal("expected error for wrong key, got nil")
+	}
+}
+
+func TestStatePayloadTTL(t *testing.T) {
+	key := deriveKey("test-ttl")
+
+	s := &StatePayload{
+		RedirectURI:   "http://localhost:1234/callback",
+		CodeChallenge: "abc123",
+		ClientID:      "test-client",
+		ClientState:   "opaque-state",
+	}
+
+	encoded, err := encryptState(key, s)
+	if err != nil {
+		t.Fatalf("encryptState: %v", err)
+	}
+
+	// Should succeed within TTL
+	decoded, err := decryptState(key, encoded, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("decryptState: %v", err)
+	}
+	if decoded.RedirectURI != s.RedirectURI {
+		t.Fatalf("unexpected redirect_uri: %s", decoded.RedirectURI)
+	}
+
+	// Should fail with very short TTL
+	_, err = decryptState(key, encoded, 0)
+	if err == nil {
+		t.Fatal("expected TTL error, got nil")
+	}
+}
+
+func TestAuthCodePayloadTTL(t *testing.T) {
+	key := deriveKey("test-authcode")
+
+	a := &AuthCodePayload{
+		AccessToken:   "access-token-123",
+		IDToken:       "id-token-456",
+		RefreshToken:  "refresh-token-789",
+		TokenType:     "Bearer",
+		ExpiresIn:     3600,
+		CodeChallenge: "challenge",
+		ClientID:      "client",
+		RedirectURI:   "http://localhost:5000/cb",
+	}
+
+	encoded, err := encryptAuthCode(key, a)
+	if err != nil {
+		t.Fatalf("encryptAuthCode: %v", err)
+	}
+
+	// Should succeed within TTL
+	decoded, err := decryptAuthCode(key, encoded, 60*time.Second)
+	if err != nil {
+		t.Fatalf("decryptAuthCode: %v", err)
+	}
+	if decoded.AccessToken != a.AccessToken {
+		t.Fatalf("unexpected access_token: %s", decoded.AccessToken)
+	}
+	if decoded.RefreshToken != a.RefreshToken {
+		t.Fatalf("unexpected refresh_token: %s", decoded.RefreshToken)
+	}
+
+	// Should fail with very short TTL
+	_, err = decryptAuthCode(key, encoded, 0)
+	if err == nil {
+		t.Fatal("expected TTL error, got nil")
+	}
+}

--- a/pkg/auth/oauth/crypto_test.go
+++ b/pkg/auth/oauth/crypto_test.go
@@ -62,7 +62,7 @@ func TestDecryptWrongKey(t *testing.T) {
 func TestStatePayloadTTL(t *testing.T) {
 	key := deriveKey("test-ttl")
 
-	s := &StatePayload{
+	s := StatePayload{
 		RedirectURI:   "http://localhost:1234/callback",
 		CodeChallenge: "abc123",
 		ClientID:      "test-client",
@@ -93,7 +93,7 @@ func TestStatePayloadTTL(t *testing.T) {
 func TestAuthCodePayloadTTL(t *testing.T) {
 	key := deriveKey("test-authcode")
 
-	a := &AuthCodePayload{
+	a := AuthCodePayload{
 		AccessToken:   "access-token-123",
 		IDToken:       "id-token-456",
 		RefreshToken:  "refresh-token-789",

--- a/pkg/auth/oauth/pkce.go
+++ b/pkg/auth/oauth/pkce.go
@@ -1,0 +1,17 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// verifyCodeChallenge validates a PKCE S256 code_verifier against a code_challenge.
+// Returns true if SHA256(code_verifier) == code_challenge (base64url-encoded, no padding).
+func verifyCodeChallenge(verifier, challenge string) bool {
+	if verifier == "" || challenge == "" {
+		return false
+	}
+	h := sha256.Sum256([]byte(verifier))
+	computed := base64.RawURLEncoding.EncodeToString(h[:])
+	return computed == challenge
+}

--- a/pkg/auth/oauth/pkce_test.go
+++ b/pkg/auth/oauth/pkce_test.go
@@ -1,0 +1,35 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+)
+
+func TestVerifyCodeChallenge_Valid(t *testing.T) {
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	h := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(h[:])
+
+	if !verifyCodeChallenge(verifier, challenge) {
+		t.Fatal("expected valid PKCE challenge to pass")
+	}
+}
+
+func TestVerifyCodeChallenge_Invalid(t *testing.T) {
+	if verifyCodeChallenge("correct-verifier", "wrong-challenge") {
+		t.Fatal("expected invalid PKCE challenge to fail")
+	}
+}
+
+func TestVerifyCodeChallenge_Empty(t *testing.T) {
+	if verifyCodeChallenge("", "challenge") {
+		t.Fatal("expected empty verifier to fail")
+	}
+	if verifyCodeChallenge("verifier", "") {
+		t.Fatal("expected empty challenge to fail")
+	}
+	if verifyCodeChallenge("", "") {
+		t.Fatal("expected both empty to fail")
+	}
+}

--- a/pkg/auth/oauth/proxy.go
+++ b/pkg/auth/oauth/proxy.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -52,7 +53,16 @@ func NewProxy(ctx context.Context, cfg Config) (*Proxy, error) {
 		return nil, fmt.Errorf("SECRET_KEY is required for MCP OAuth proxy")
 	}
 
-	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
+	oidcCtx := ctx
+	if cfg.TLSInsecure {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		hc := &http.Client{Transport: tr}
+		oidcCtx = oidc.ClientContext(ctx, hc)
+	}
+
+	provider, err := oidc.NewProvider(oidcCtx, cfg.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("oidc discovery: %w", err)
 	}
@@ -101,24 +111,24 @@ func (p *Proxy) callbackURL(r *http.Request) string {
 	if p.redirectURL != "" {
 		return p.redirectURL
 	}
-	scheme := "https"
-	if r.TLS == nil {
-		if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
-			scheme = fwd
-		}
-	}
-	return scheme + "://" + r.Host + "/oauth/callback"
+	return requestScheme(r) + "://" + r.Host + "/oauth/callback"
 }
 
 // baseURL returns the base URL of the Hugr server derived from the request.
 func baseURL(r *http.Request) string {
-	scheme := "https"
-	if r.TLS == nil {
-		if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
-			scheme = fwd
-		}
+	return requestScheme(r) + "://" + r.Host
+}
+
+// requestScheme detects the scheme from TLS state, X-Forwarded-Proto header,
+// or defaults to http for plain connections.
+func requestScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
 	}
-	return scheme + "://" + r.Host
+	if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
+		return fwd
+	}
+	return "http"
 }
 
 // handleMetadata serves the OAuth 2.1 Authorization Server Metadata.

--- a/pkg/auth/oauth/proxy.go
+++ b/pkg/auth/oauth/proxy.go
@@ -42,6 +42,7 @@ type Config struct {
 type Proxy struct {
 	oauth2Config oauth2.Config
 	oidcProvider *oidc.Provider
+	httpClient   *http.Client // used for refresh token proxy
 	key          []byte
 	redirectURL  string // optional override
 	tokenURL     string // OIDC provider's token endpoint (for refresh proxy)
@@ -80,8 +81,18 @@ func NewProxy(ctx context.Context, cfg Config) (*Proxy, error) {
 		return nil, fmt.Errorf("oidc provider claims: %w", err)
 	}
 
+	hc := http.DefaultClient
+	if cfg.TLSInsecure {
+		hc = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+	}
+
 	p := &Proxy{
 		oidcProvider: provider,
+		httpClient:   hc,
 		key:          deriveKey(cfg.SecretKey),
 		redirectURL:  cfg.RedirectURL,
 		tokenURL:     providerClaims.TokenEndpoint,
@@ -125,8 +136,8 @@ func requestScheme(r *http.Request) string {
 	if r.TLS != nil {
 		return "https"
 	}
-	if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
-		return fwd
+	if fwd := r.Header.Get("X-Forwarded-Proto"); fwd == "https" {
+		return "https"
 	}
 	return "http"
 }
@@ -178,7 +189,7 @@ func (p *Proxy) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	payload := &StatePayload{
+	payload := StatePayload{
 		RedirectURI:   redirectURI,
 		CodeChallenge: codeChallenge,
 		ClientID:      clientID,
@@ -237,7 +248,7 @@ func (p *Proxy) handleCallback(w http.ResponseWriter, r *http.Request) {
 
 	idTokenRaw, _ := token.Extra("id_token").(string)
 
-	authCode := &AuthCodePayload{
+	authCode := AuthCodePayload{
 		AccessToken:   token.AccessToken,
 		IDToken:       idTokenRaw,
 		RefreshToken:  token.RefreshToken,
@@ -352,7 +363,7 @@ func (p *Proxy) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 		"client_secret": {p.oauth2Config.ClientSecret},
 	}
 
-	resp, err := http.PostForm(p.tokenURL, data)
+	resp, err := p.httpClient.PostForm(p.tokenURL, data)
 	if err != nil {
 		log.Printf("oauth: refresh proxy error: %v", err)
 		oauthError(w, http.StatusBadGateway, "server_error", "failed to contact OIDC provider")
@@ -360,15 +371,16 @@ func (p *Proxy) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "no-store")
-	w.WriteHeader(resp.StatusCode)
-
 	var body json.RawMessage
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		log.Printf("oauth: refresh response decode error: %v", err)
 		oauthError(w, http.StatusBadGateway, "server_error", "invalid response from OIDC provider")
 		return
 	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(resp.StatusCode)
 	json.NewEncoder(w).Encode(body)
 }
 

--- a/pkg/auth/oauth/proxy.go
+++ b/pkg/auth/oauth/proxy.go
@@ -1,0 +1,441 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+const (
+	stateTTL    = 5 * time.Minute
+	authCodeTTL = 60 * time.Second
+)
+
+// Config holds the configuration for the OAuth proxy.
+type Config struct {
+	// OIDC provider settings
+	Issuer       string
+	ClientID     string
+	ClientSecret string
+	Scopes       string
+	RedirectURL  string // optional override for callback URL derivation
+	TLSInsecure  bool
+
+	// Encryption key for state and auth codes
+	SecretKey string
+}
+
+// Proxy is a stateless OAuth 2.1 proxy that delegates authentication
+// to an external OIDC provider. It encrypts all transient state into
+// request/response parameters using AES-GCM.
+type Proxy struct {
+	oauth2Config oauth2.Config
+	oidcProvider *oidc.Provider
+	key          []byte
+	redirectURL  string // optional override
+	tokenURL     string // OIDC provider's token endpoint (for refresh proxy)
+}
+
+// NewProxy creates a new OAuth proxy by performing OIDC discovery.
+func NewProxy(ctx context.Context, cfg Config) (*Proxy, error) {
+	if cfg.SecretKey == "" {
+		return nil, fmt.Errorf("SECRET_KEY is required for MCP OAuth proxy")
+	}
+
+	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("oidc discovery: %w", err)
+	}
+
+	scopes := []string{oidc.ScopeOpenID}
+	if cfg.Scopes != "" {
+		scopes = strings.Fields(cfg.Scopes)
+	}
+
+	// Extract token endpoint from provider for refresh proxy
+	var providerClaims struct {
+		TokenEndpoint string `json:"token_endpoint"`
+	}
+	if err := provider.Claims(&providerClaims); err != nil {
+		return nil, fmt.Errorf("oidc provider claims: %w", err)
+	}
+
+	p := &Proxy{
+		oidcProvider: provider,
+		key:          deriveKey(cfg.SecretKey),
+		redirectURL:  cfg.RedirectURL,
+		tokenURL:     providerClaims.TokenEndpoint,
+		oauth2Config: oauth2.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			Endpoint:     provider.Endpoint(),
+			Scopes:       scopes,
+		},
+	}
+
+	return p, nil
+}
+
+// RegisterHandlers registers all OAuth proxy endpoints on the mux.
+func (p *Proxy) RegisterHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("GET /.well-known/oauth-authorization-server", p.handleMetadata)
+	mux.HandleFunc("GET /oauth/authorize", p.handleAuthorize)
+	mux.HandleFunc("GET /oauth/callback", p.handleCallback)
+	mux.HandleFunc("POST /oauth/token", p.handleToken)
+	mux.HandleFunc("POST /oauth/register", p.handleRegister)
+}
+
+// callbackURL returns the OAuth callback URL for Hugr.
+// Uses the configured RedirectURL if set, otherwise derives from the request Host header.
+func (p *Proxy) callbackURL(r *http.Request) string {
+	if p.redirectURL != "" {
+		return p.redirectURL
+	}
+	scheme := "https"
+	if r.TLS == nil {
+		if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
+			scheme = fwd
+		}
+	}
+	return scheme + "://" + r.Host + "/oauth/callback"
+}
+
+// baseURL returns the base URL of the Hugr server derived from the request.
+func baseURL(r *http.Request) string {
+	scheme := "https"
+	if r.TLS == nil {
+		if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
+			scheme = fwd
+		}
+	}
+	return scheme + "://" + r.Host
+}
+
+// handleMetadata serves the OAuth 2.1 Authorization Server Metadata.
+func (p *Proxy) handleMetadata(w http.ResponseWriter, r *http.Request) {
+	base := baseURL(r)
+	metadata := map[string]any{
+		"issuer":                                base,
+		"authorization_endpoint":                base + "/oauth/authorize",
+		"token_endpoint":                        base + "/oauth/token",
+		"registration_endpoint":                 base + "/oauth/register",
+		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+		"code_challenge_methods_supported":      []string{"S256"},
+		"scopes_supported":                      []string{},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(metadata)
+}
+
+// handleAuthorize starts the OAuth flow by encrypting the MCP client's
+// session into the state parameter and redirecting to the OIDC provider.
+func (p *Proxy) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	responseType := q.Get("response_type")
+	clientID := q.Get("client_id")
+	redirectURI := q.Get("redirect_uri")
+	state := q.Get("state")
+	codeChallenge := q.Get("code_challenge")
+	codeChallengeMethod := q.Get("code_challenge_method")
+
+	if responseType != "code" {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "response_type must be 'code'")
+		return
+	}
+	if clientID == "" || redirectURI == "" || state == "" || codeChallenge == "" {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "missing required parameters")
+		return
+	}
+	if codeChallengeMethod != "S256" {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "code_challenge_method must be 'S256'")
+		return
+	}
+	if !isValidRedirectURI(redirectURI) {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "redirect_uri must be localhost or HTTPS")
+		return
+	}
+
+	payload := &StatePayload{
+		RedirectURI:   redirectURI,
+		CodeChallenge: codeChallenge,
+		ClientID:      clientID,
+		ClientState:   state,
+	}
+	encryptedState, err := encryptState(p.key, payload)
+	if err != nil {
+		log.Printf("oauth: encrypt state error: %v", err)
+		oauthError(w, http.StatusInternalServerError, "server_error", "failed to process request")
+		return
+	}
+
+	cfg := p.oauth2Config
+	cfg.RedirectURL = p.callbackURL(r)
+
+	authURL := cfg.AuthCodeURL(encryptedState)
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// handleCallback receives the OIDC provider's callback, exchanges the code
+// for tokens, encrypts them into a Hugr authorization code, and redirects
+// back to the MCP client.
+func (p *Proxy) handleCallback(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	if errCode := q.Get("error"); errCode != "" {
+		errDesc := q.Get("error_description")
+		log.Printf("oauth: OIDC provider error: %s: %s", errCode, errDesc)
+		oauthError(w, http.StatusBadRequest, errCode, errDesc)
+		return
+	}
+
+	code := q.Get("code")
+	encryptedState := q.Get("state")
+	if code == "" || encryptedState == "" {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "missing code or state")
+		return
+	}
+
+	state, err := decryptState(p.key, encryptedState, stateTTL)
+	if err != nil {
+		log.Printf("oauth: decrypt state error: %v", err)
+		oauthError(w, http.StatusBadRequest, "invalid_request", "invalid or expired state")
+		return
+	}
+
+	cfg := p.oauth2Config
+	cfg.RedirectURL = p.callbackURL(r)
+
+	token, err := cfg.Exchange(r.Context(), code)
+	if err != nil {
+		log.Printf("oauth: token exchange error: %v", err)
+		oauthError(w, http.StatusBadGateway, "server_error", "failed to exchange authorization code with OIDC provider")
+		return
+	}
+
+	idTokenRaw, _ := token.Extra("id_token").(string)
+
+	authCode := &AuthCodePayload{
+		AccessToken:   token.AccessToken,
+		IDToken:       idTokenRaw,
+		RefreshToken:  token.RefreshToken,
+		TokenType:     token.TokenType,
+		ExpiresIn:     int64(time.Until(token.Expiry).Seconds()),
+		CodeChallenge: state.CodeChallenge,
+		ClientID:      state.ClientID,
+		RedirectURI:   state.RedirectURI,
+	}
+
+	encryptedCode, err := encryptAuthCode(p.key, authCode)
+	if err != nil {
+		log.Printf("oauth: encrypt auth code error: %v", err)
+		oauthError(w, http.StatusInternalServerError, "server_error", "failed to process request")
+		return
+	}
+
+	redirectURL, err := url.Parse(state.RedirectURI)
+	if err != nil {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "invalid redirect_uri")
+		return
+	}
+	rq := redirectURL.Query()
+	rq.Set("code", encryptedCode)
+	rq.Set("state", state.ClientState)
+	redirectURL.RawQuery = rq.Encode()
+
+	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+}
+
+// handleToken exchanges an encrypted authorization code for OIDC tokens,
+// or proxies a refresh token request to the OIDC provider.
+func (p *Proxy) handleToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "malformed request body")
+		return
+	}
+
+	grantType := r.FormValue("grant_type")
+
+	switch grantType {
+	case "authorization_code":
+		p.handleTokenAuthorizationCode(w, r)
+	case "refresh_token":
+		p.handleTokenRefresh(w, r)
+	default:
+		oauthError(w, http.StatusBadRequest, "unsupported_grant_type", "grant_type must be 'authorization_code' or 'refresh_token'")
+	}
+}
+
+func (p *Proxy) handleTokenAuthorizationCode(w http.ResponseWriter, r *http.Request) {
+	code := r.FormValue("code")
+	redirectURI := r.FormValue("redirect_uri")
+	clientID := r.FormValue("client_id")
+	codeVerifier := r.FormValue("code_verifier")
+
+	if code == "" || redirectURI == "" || clientID == "" || codeVerifier == "" {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "missing required parameters")
+		return
+	}
+
+	authCode, err := decryptAuthCode(p.key, code, authCodeTTL)
+	if err != nil {
+		log.Printf("oauth: decrypt auth code error: %v", err)
+		oauthError(w, http.StatusBadRequest, "invalid_grant", "invalid or expired authorization code")
+		return
+	}
+
+	if authCode.ClientID != clientID {
+		oauthError(w, http.StatusBadRequest, "invalid_grant", "client_id mismatch")
+		return
+	}
+	if authCode.RedirectURI != redirectURI {
+		oauthError(w, http.StatusBadRequest, "invalid_grant", "redirect_uri mismatch")
+		return
+	}
+	if !verifyCodeChallenge(codeVerifier, authCode.CodeChallenge) {
+		oauthError(w, http.StatusBadRequest, "invalid_grant", "PKCE verification failed")
+		return
+	}
+
+	resp := map[string]any{
+		"access_token": authCode.AccessToken,
+		"token_type":   authCode.TokenType,
+	}
+	if authCode.ExpiresIn > 0 {
+		resp["expires_in"] = authCode.ExpiresIn
+	}
+	if authCode.IDToken != "" {
+		resp["id_token"] = authCode.IDToken
+	}
+	if authCode.RefreshToken != "" {
+		resp["refresh_token"] = authCode.RefreshToken
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (p *Proxy) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	refreshToken := r.FormValue("refresh_token")
+	if refreshToken == "" {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "missing refresh_token")
+		return
+	}
+
+	data := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {p.oauth2Config.ClientID},
+		"client_secret": {p.oauth2Config.ClientSecret},
+	}
+
+	resp, err := http.PostForm(p.tokenURL, data)
+	if err != nil {
+		log.Printf("oauth: refresh proxy error: %v", err)
+		oauthError(w, http.StatusBadGateway, "server_error", "failed to contact OIDC provider")
+		return
+	}
+	defer resp.Body.Close()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(resp.StatusCode)
+
+	var body json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		oauthError(w, http.StatusBadGateway, "server_error", "invalid response from OIDC provider")
+		return
+	}
+	json.NewEncoder(w).Encode(body)
+}
+
+// handleRegister implements stateless dynamic client registration (RFC 7591).
+func (p *Proxy) handleRegister(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RedirectURIs            []string `json:"redirect_uris"`
+		ClientName              string   `json:"client_name"`
+		GrantTypes              []string `json:"grant_types"`
+		ResponseTypes           []string `json:"response_types"`
+		TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		oauthError(w, http.StatusBadRequest, "invalid_client_metadata", "malformed JSON body")
+		return
+	}
+
+	if len(req.RedirectURIs) == 0 {
+		oauthError(w, http.StatusBadRequest, "invalid_client_metadata", "redirect_uris is required")
+		return
+	}
+	for _, uri := range req.RedirectURIs {
+		if !isValidRedirectURI(uri) {
+			oauthError(w, http.StatusBadRequest, "invalid_redirect_uri", "redirect_uri must be localhost or HTTPS: "+uri)
+			return
+		}
+	}
+
+	if len(req.GrantTypes) == 0 {
+		req.GrantTypes = []string{"authorization_code"}
+	}
+	if len(req.ResponseTypes) == 0 {
+		req.ResponseTypes = []string{"code"}
+	}
+
+	clientID := generateClientID()
+
+	resp := map[string]any{
+		"client_id":                    clientID,
+		"client_id_issued_at":          time.Now().Unix(),
+		"redirect_uris":               req.RedirectURIs,
+		"client_name":                 req.ClientName,
+		"grant_types":                 req.GrantTypes,
+		"response_types":              req.ResponseTypes,
+		"token_endpoint_auth_method":  "none",
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(resp)
+}
+
+// isValidRedirectURI checks that a redirect URI is localhost or HTTPS.
+func isValidRedirectURI(rawURI string) bool {
+	u, err := url.Parse(rawURI)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]" {
+		return true
+	}
+	return u.Scheme == "https"
+}
+
+func generateClientID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return "hugr_mcp_" + hex.EncodeToString(b)
+}
+
+func oauthError(w http.ResponseWriter, status int, code, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error":             code,
+		"error_description": description,
+	})
+}

--- a/pkg/auth/oauth/proxy_test.go
+++ b/pkg/auth/oauth/proxy_test.go
@@ -155,7 +155,7 @@ func TestHandleToken_AuthorizationCode_Success(t *testing.T) {
 	challenge := base64.RawURLEncoding.EncodeToString(h[:])
 
 	// Create a valid encrypted auth code
-	authCode := &AuthCodePayload{
+	authCode := AuthCodePayload{
 		AccessToken:   "oidc-access-token",
 		IDToken:       "oidc-id-token",
 		RefreshToken:  "oidc-refresh-token",
@@ -208,7 +208,7 @@ func TestHandleToken_PKCEMismatch(t *testing.T) {
 	mux := http.NewServeMux()
 	p.RegisterHandlers(mux)
 
-	authCode := &AuthCodePayload{
+	authCode := AuthCodePayload{
 		AccessToken:   "token",
 		TokenType:     "Bearer",
 		CodeChallenge: "correct-challenge",
@@ -247,7 +247,7 @@ func TestHandleToken_ExpiredCode(t *testing.T) {
 	p.RegisterHandlers(mux)
 
 	// Manually create an expired auth code
-	authCode := &AuthCodePayload{
+	authCode := AuthCodePayload{
 		AccessToken:   "token",
 		TokenType:     "Bearer",
 		CodeChallenge: "challenge",
@@ -280,7 +280,7 @@ func TestHandleToken_ClientIDMismatch(t *testing.T) {
 	mux := http.NewServeMux()
 	p.RegisterHandlers(mux)
 
-	authCode := &AuthCodePayload{
+	authCode := AuthCodePayload{
 		AccessToken:   "token",
 		TokenType:     "Bearer",
 		CodeChallenge: "challenge",

--- a/pkg/auth/oauth/proxy_test.go
+++ b/pkg/auth/oauth/proxy_test.go
@@ -1,0 +1,429 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// testProxy creates a Proxy with a test key (no OIDC discovery).
+func testProxy(t *testing.T) *Proxy {
+	t.Helper()
+	key := deriveKey("test-secret-key-32-chars-minimum")
+	return &Proxy{
+		key:      key,
+		tokenURL: "http://oidc.example.com/token",
+		oauth2Config: oauth2.Config{
+			ClientID:     "hugr-client",
+			ClientSecret: "hugr-secret",
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  "http://oidc.example.com/authorize",
+				TokenURL: "http://oidc.example.com/token",
+			},
+			Scopes: []string{"openid", "profile", "email"},
+		},
+	}
+}
+
+func TestHandleMetadata(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	req := httptest.NewRequest("GET", "https://hugr.example.com/.well-known/oauth-authorization-server", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var metadata map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&metadata); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if metadata["issuer"] != "https://hugr.example.com" {
+		t.Fatalf("unexpected issuer: %v", metadata["issuer"])
+	}
+	if metadata["authorization_endpoint"] != "https://hugr.example.com/oauth/authorize" {
+		t.Fatalf("unexpected authorization_endpoint: %v", metadata["authorization_endpoint"])
+	}
+	if metadata["token_endpoint"] != "https://hugr.example.com/oauth/token" {
+		t.Fatalf("unexpected token_endpoint: %v", metadata["token_endpoint"])
+	}
+	if metadata["registration_endpoint"] != "https://hugr.example.com/oauth/register" {
+		t.Fatalf("unexpected registration_endpoint: %v", metadata["registration_endpoint"])
+	}
+}
+
+func TestHandleAuthorize_Success(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	h := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(h[:])
+
+	params := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"test-client"},
+		"redirect_uri":          {"http://localhost:12345/callback"},
+		"state":                 {"client-state-123"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}
+
+	req := httptest.NewRequest("GET", "https://hugr.example.com/oauth/authorize?"+params.Encode(), nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d: %s", w.Code, w.Body.String())
+	}
+
+	location := w.Header().Get("Location")
+	if !strings.HasPrefix(location, "http://oidc.example.com/authorize") {
+		t.Fatalf("expected redirect to OIDC provider, got: %s", location)
+	}
+
+	redirectURL, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	if redirectURL.Query().Get("client_id") != "hugr-client" {
+		t.Fatalf("expected hugr-client client_id, got: %s", redirectURL.Query().Get("client_id"))
+	}
+	if redirectURL.Query().Get("state") == "" {
+		t.Fatal("expected encrypted state in redirect")
+	}
+}
+
+func TestHandleAuthorize_MissingParams(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	req := httptest.NewRequest("GET", "https://hugr.example.com/oauth/authorize?response_type=code", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleAuthorize_InvalidRedirectURI(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	params := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"test"},
+		"redirect_uri":          {"http://evil.com/callback"},
+		"state":                 {"s"},
+		"code_challenge":        {"c"},
+		"code_challenge_method": {"S256"},
+	}
+
+	req := httptest.NewRequest("GET", "https://hugr.example.com/oauth/authorize?"+params.Encode(), nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-localhost non-HTTPS redirect, got %d", w.Code)
+	}
+}
+
+func TestHandleToken_AuthorizationCode_Success(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	h := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(h[:])
+
+	// Create a valid encrypted auth code
+	authCode := &AuthCodePayload{
+		AccessToken:   "oidc-access-token",
+		IDToken:       "oidc-id-token",
+		RefreshToken:  "oidc-refresh-token",
+		TokenType:     "Bearer",
+		ExpiresIn:     3600,
+		CodeChallenge: challenge,
+		ClientID:      "test-client",
+		RedirectURI:   "http://localhost:12345/callback",
+	}
+	encryptedCode, err := encryptAuthCode(p.key, authCode)
+	if err != nil {
+		t.Fatalf("encrypt auth code: %v", err)
+	}
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {encryptedCode},
+		"redirect_uri":  {"http://localhost:12345/callback"},
+		"client_id":     {"test-client"},
+		"code_verifier": {verifier},
+	}
+
+	req := httptest.NewRequest("POST", "https://hugr.example.com/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp["access_token"] != "oidc-access-token" {
+		t.Fatalf("unexpected access_token: %v", resp["access_token"])
+	}
+	if resp["id_token"] != "oidc-id-token" {
+		t.Fatalf("unexpected id_token: %v", resp["id_token"])
+	}
+	if resp["refresh_token"] != "oidc-refresh-token" {
+		t.Fatalf("unexpected refresh_token: %v", resp["refresh_token"])
+	}
+}
+
+func TestHandleToken_PKCEMismatch(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	authCode := &AuthCodePayload{
+		AccessToken:   "token",
+		TokenType:     "Bearer",
+		CodeChallenge: "correct-challenge",
+		ClientID:      "client",
+		RedirectURI:   "http://localhost:1234/cb",
+	}
+	encryptedCode, _ := encryptAuthCode(p.key, authCode)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {encryptedCode},
+		"redirect_uri":  {"http://localhost:1234/cb"},
+		"client_id":     {"client"},
+		"code_verifier": {"wrong-verifier"},
+	}
+
+	req := httptest.NewRequest("POST", "https://hugr.example.com/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for PKCE mismatch, got %d", w.Code)
+	}
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "invalid_grant" {
+		t.Fatalf("expected invalid_grant error, got: %s", resp["error"])
+	}
+}
+
+func TestHandleToken_ExpiredCode(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	// Manually create an expired auth code
+	authCode := &AuthCodePayload{
+		AccessToken:   "token",
+		TokenType:     "Bearer",
+		CodeChallenge: "challenge",
+		ClientID:      "client",
+		RedirectURI:   "http://localhost:1234/cb",
+		Timestamp:     time.Now().Add(-2 * time.Minute).Unix(), // expired
+	}
+	encryptedCode, _ := encrypt(p.key, authCode)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {encryptedCode},
+		"redirect_uri":  {"http://localhost:1234/cb"},
+		"client_id":     {"client"},
+		"code_verifier": {"verifier"},
+	}
+
+	req := httptest.NewRequest("POST", "https://hugr.example.com/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for expired code, got %d", w.Code)
+	}
+}
+
+func TestHandleToken_ClientIDMismatch(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	authCode := &AuthCodePayload{
+		AccessToken:   "token",
+		TokenType:     "Bearer",
+		CodeChallenge: "challenge",
+		ClientID:      "correct-client",
+		RedirectURI:   "http://localhost:1234/cb",
+	}
+	encryptedCode, _ := encryptAuthCode(p.key, authCode)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {encryptedCode},
+		"redirect_uri":  {"http://localhost:1234/cb"},
+		"client_id":     {"wrong-client"},
+		"code_verifier": {"verifier"},
+	}
+
+	req := httptest.NewRequest("POST", "https://hugr.example.com/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for client_id mismatch, got %d", w.Code)
+	}
+}
+
+func TestHandleToken_TamperedCode(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {"this-is-not-a-valid-encrypted-code"},
+		"redirect_uri":  {"http://localhost:1234/cb"},
+		"client_id":     {"client"},
+		"code_verifier": {"verifier"},
+	}
+
+	req := httptest.NewRequest("POST", "https://hugr.example.com/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for tampered code, got %d", w.Code)
+	}
+}
+
+func TestHandleRegister_Success(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	body := `{"redirect_uris": ["http://localhost:12345/callback"], "client_name": "Test Client"}`
+	req := httptest.NewRequest("POST", "https://hugr.example.com/oauth/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	clientID, ok := resp["client_id"].(string)
+	if !ok || !strings.HasPrefix(clientID, "hugr_mcp_") {
+		t.Fatalf("unexpected client_id: %v", resp["client_id"])
+	}
+}
+
+func TestHandleRegister_InvalidRedirectURI(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	body := `{"redirect_uris": ["http://evil.com/callback"]}`
+	req := httptest.NewRequest("POST", "https://hugr.example.com/oauth/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-localhost redirect, got %d", w.Code)
+	}
+}
+
+func TestHandleRegister_MissingRedirectURIs(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	body := `{"client_name": "No URIs"}`
+	req := httptest.NewRequest("POST", "https://hugr.example.com/oauth/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing redirect_uris, got %d", w.Code)
+	}
+}
+
+func TestHandleRegister_HTTPSRedirectURI(t *testing.T) {
+	p := testProxy(t)
+	mux := http.NewServeMux()
+	p.RegisterHandlers(mux)
+
+	body := `{"redirect_uris": ["https://app.example.com/callback"]}`
+	req := httptest.NewRequest("POST", "https://hugr.example.com/oauth/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for HTTPS redirect, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestIsValidRedirectURI(t *testing.T) {
+	tests := []struct {
+		uri  string
+		want bool
+	}{
+		{"http://localhost:12345/callback", true},
+		{"http://localhost/callback", true},
+		{"http://127.0.0.1:8080/cb", true},
+		{"https://app.example.com/callback", true},
+		{"http://evil.com/callback", false},
+		{"http://192.168.1.1:8080/cb", false},
+		{"ftp://localhost/cb", true}, // localhost is always allowed
+		{"not-a-url", false},
+	}
+
+	for _, tt := range tests {
+		got := isValidRedirectURI(tt.uri)
+		if got != tt.want {
+			t.Errorf("isValidRedirectURI(%q) = %v, want %v", tt.uri, got, tt.want)
+		}
+	}
+}
+

--- a/pkg/auth/oidc_provider.go
+++ b/pkg/auth/oidc_provider.go
@@ -15,11 +15,14 @@ import (
 )
 
 type OIDCConfig struct {
-	Issuer      string        `json:"issuer" yaml:"issuer"`
-	ClientID    string        `json:"client_id" yaml:"client_id"`
-	Timeout     time.Duration `json:"timeout" yaml:"timeout"`
-	TLSInsecure bool          `json:"tls_insecure" yaml:"tls_insecure"`
-	CookieName  string        `json:"cookie_name" yaml:"cookie_name"`
+	Issuer       string        `json:"issuer" yaml:"issuer"`
+	ClientID     string        `json:"client_id" yaml:"client_id"`
+	ClientSecret string        `json:"-" yaml:"client_secret"`
+	Timeout      time.Duration `json:"timeout" yaml:"timeout"`
+	TLSInsecure  bool          `json:"tls_insecure" yaml:"tls_insecure"`
+	CookieName   string        `json:"cookie_name" yaml:"cookie_name"`
+	Scopes       string        `json:"scopes" yaml:"scopes"`
+	RedirectURL  string        `json:"redirect_url" yaml:"redirect_url"`
 
 	ScopeRolePrefix string     `json:"scope_role_prefix" yaml:"scope_role_prefix"`
 	Claims          OIDCClaims `json:"claims" yaml:"claims"`


### PR DESCRIPTION
## Summary

- Add stateless OAuth 2.1 proxy in `pkg/auth/oauth/` enabling MCP clients (Claude Desktop, Cursor) to authenticate via external OIDC providers (Keycloak, EntraID, Auth0)
- Proxy encrypts all transient state into request parameters (AES-256-GCM with `SECRET_KEY`) — zero server-side storage, works identically in standalone and cluster modes
- Hugr passes through OIDC provider's tokens — does not issue its own tokens or store user information

### OAuth Endpoints
- `GET /.well-known/oauth-authorization-server` — metadata discovery
- `GET /oauth/authorize` — redirect to OIDC provider
- `GET /oauth/callback` — exchange OIDC code, redirect to MCP client
- `POST /oauth/token` — decrypt auth code, verify PKCE, return tokens; proxy refresh_token grants
- `POST /oauth/register` — stateless dynamic client registration (RFC 7591)

### New Environment Variables
- `MCP_OAUTH_CLIENT_ID` / `MCP_OAUTH_CLIENT_SECRET` — dedicated OIDC client for MCP (falls back to `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET`)
- `OIDC_CLIENT_SECRET` — client secret for authorization code exchange
- `OIDC_SCOPES` — scopes to request (default: `openid profile email`)
- `OIDC_REDIRECT_URL` — optional callback URL override for proxy/tunnel setups

### Tested
- 22 unit tests (crypto, PKCE, all OAuth handlers, error cases)
- End-to-end with Keycloak + Cloudflare tunnel + Claude Desktop

## Test plan
- [x] Unit tests pass: `go test ./pkg/auth/oauth/...`
- [x] Build passes: `go build -tags=duckdb_arrow ./cmd/server/`
- [x] Metadata endpoint returns correct OAuth 2.1 metadata
- [x] Dynamic client registration returns client_id
- [x] Authorize redirects to OIDC provider with encrypted state
- [x] Callback exchanges code and redirects with encrypted auth code
- [x] Token exchange decrypts code, verifies PKCE, returns OIDC tokens
- [x] Full flow tested with Keycloak + Cloudflare tunnel + Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)