### PR TITLE
fix(auth): OIDC falls through to next provider on a foreign token

### DIFF
--- a/pkg/auth/oidc_provider.go
+++ b/pkg/auth/oidc_provider.go
@@ -103,7 +103,10 @@ func (p *OIDCProvider) Authenticate(r *http.Request) (*auth.AuthInfo, error) {
 		return nil, err
 	}
 	if token == "" {
-		return nil, nil
+		// An empty credential is treated as "no token" so it does not block the
+		// chain; returning (nil, nil) here would bypass the middleware's
+		// rejected-token guard and could downgrade to anonymous access.
+		return nil, auth.ErrSkipAuth
 	}
 
 	idToken, err := p.verifier.Verify(r.Context(), token)
@@ -111,10 +114,14 @@ func (p *OIDCProvider) Authenticate(r *http.Request) (*auth.AuthInfo, error) {
 		return nil, auth.ErrTokenExpired
 	}
 	if err != nil {
-		// The token could not be verified by this OIDC provider (wrong
-		// issuer/signature) — most likely issued for a different provider.
-		// Signal the middleware to try the next provider instead of failing
-		// outright; a token rejected by every provider still yields 401.
+		// Verification failed. If the token was issued by this provider's issuer
+		// it is genuinely our token but invalid (bad signature/audience/nbf, or
+		// the IdP is unreachable) — a hard failure. Otherwise it was issued for a
+		// different provider, so let the middleware try the next one (a token no
+		// provider accepts still ends in 401, never anonymous).
+		if p.tokenIssuedHere(token) {
+			return nil, auth.ErrForbidden
+		}
 		return nil, auth.ErrInvalidKeyType
 	}
 
@@ -144,6 +151,21 @@ func (p *OIDCProvider) Authenticate(r *http.Request) (*auth.AuthInfo, error) {
 		AuthProvider: p.Name(),
 		Token:        token,
 	}, nil
+}
+
+// tokenIssuedHere reports whether the token's `iss` claim matches this
+// provider's configured issuer. It parses the JWT WITHOUT verifying the
+// signature — used only to classify a verification failure as a hard error
+// (our issuer's token, genuinely invalid) versus a fallthrough to the next
+// provider (a different issuer's token). A non-JWT or different/empty issuer is
+// treated as "not ours".
+func (p *OIDCProvider) tokenIssuedHere(token string) bool {
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {
+		return false
+	}
+	iss, _ := claims["iss"].(string)
+	return iss == p.c.Issuer
 }
 
 // claimString extracts a string value from a claim, if prefix is provided, it return only unprefixed value with it.

--- a/pkg/auth/oidc_provider.go
+++ b/pkg/auth/oidc_provider.go
@@ -111,7 +111,11 @@ func (p *OIDCProvider) Authenticate(r *http.Request) (*auth.AuthInfo, error) {
 		return nil, auth.ErrTokenExpired
 	}
 	if err != nil {
-		return nil, auth.ErrForbidden
+		// The token could not be verified by this OIDC provider (wrong
+		// issuer/signature) — most likely issued for a different provider.
+		// Signal the middleware to try the next provider instead of failing
+		// outright; a token rejected by every provider still yields 401.
+		return nil, auth.ErrInvalidKeyType
 	}
 
 	claims := jwt.MapClaims{}

--- a/pkg/auth/oidc_provider_test.go
+++ b/pkg/auth/oidc_provider_test.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/hugr-lab/query-engine/pkg/auth"
+)
+
+type stubVerifier struct{ err error }
+
+func (s stubVerifier) Verify(ctx context.Context, token string) (*oidc.IDToken, error) {
+	return nil, s.err
+}
+
+type stubExtractor string
+
+func (s stubExtractor) ExtractToken(*http.Request) (string, error) { return string(s), nil }
+
+func oidcTokenWithIssuer(t *testing.T, iss string) string {
+	t.Helper()
+	s, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"iss": iss, "sub": "u"}).SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return s
+}
+
+// A Verify failure must be classified by issuer: a token from a different
+// issuer falls through to the next provider (ErrInvalidKeyType), while a token
+// from this provider's own issuer is a hard failure (ErrForbidden) — a genuine
+// verify error (bad signature/audience/nbf, or the IdP being unreachable) must
+// not be silently rerouted. An empty credential is treated as no token.
+func TestOIDCProvider_Authenticate_Classification(t *testing.T) {
+	verifyErr := errors.New("verify failed")
+	req := httptest.NewRequest("GET", "/", nil)
+
+	newP := func(issuer, token string) *OIDCProvider {
+		return &OIDCProvider{
+			c:         OIDCConfig{Issuer: issuer},
+			verifier:  stubVerifier{err: verifyErr},
+			extractor: stubExtractor(token),
+		}
+	}
+
+	t.Run("verify fails, foreign issuer -> ErrInvalidKeyType (fall through)", func(t *testing.T) {
+		_, err := newP("https://us", oidcTokenWithIssuer(t, "https://them")).Authenticate(req)
+		if !errors.Is(err, auth.ErrInvalidKeyType) {
+			t.Fatalf("err = %v, want ErrInvalidKeyType", err)
+		}
+	})
+
+	t.Run("verify fails, our issuer -> ErrForbidden (hard fail)", func(t *testing.T) {
+		_, err := newP("https://us", oidcTokenWithIssuer(t, "https://us")).Authenticate(req)
+		if !errors.Is(err, auth.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+
+	t.Run("empty token -> ErrSkipAuth", func(t *testing.T) {
+		_, err := newP("https://us", "").Authenticate(req)
+		if !errors.Is(err, auth.ErrSkipAuth) {
+			t.Fatalf("err = %v, want ErrSkipAuth", err)
+		}
+	})
+}


### PR DESCRIPTION
> ⚠️ **Blocked on query-engine release.** This PR uses `auth.ErrInvalidKeyType`, added in query-engine [#126](https://github.com/hugr-lab/query-engine/pull/126) (merged, not yet released). CI will fail until `go.mod` is bumped to the query-engine release that ships `ErrInvalidKeyType` — that bump lands as part of the release process. Draft until then.

## Problem

With multiple auth providers configured, the OIDC provider hard-failed with `auth.ErrForbidden` whenever `verifier.Verify()` rejected a token — even a token simply issued for a **different** provider — so the middleware returned 401 without trying the remaining providers.

## Change

- On a `Verify` failure, classify by the token's **issuer**:
  - `iss` matches this provider's configured issuer → genuinely our token but invalid (bad signature/audience/nbf, or the IdP is unreachable) → **`ErrForbidden`** (hard 401, not masked as fallthrough);
  - different / absent / unparseable issuer → **`ErrInvalidKeyType`** → the middleware tries the next provider (a token no provider accepts still ends in 401, never anonymous).
- An empty credential now returns **`ErrSkipAuth`** instead of `(nil, nil)`, so it can't bypass the middleware's rejected-token guard.
- `TokenExpired` and the post-verify authorization failures (missing role, bad claims) stay as `ErrTokenExpired` / `ErrForbidden`.

## Testing

`oidc_provider_test.go` (first tests in this package) — Verify-failure classification: foreign issuer → fallthrough, our issuer → forbidden, empty token → skip. Green in the workspace against local query-engine.

## Pairs with
query-engine #126 (JWT provider + middleware fallthrough, `ErrInvalidKeyType` sentinel, anonymous-last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)